### PR TITLE
added real ip forwarding in nginx config

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -52,6 +52,9 @@ http {
     location /api {
         proxy_pass http://wwts_api:3000;
         rewrite ^/api(/.*)$ $1 break;
+      
+        proxy_set_header        X-Real-IP       $remote_addr;
+        proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
     }
   }
 }


### PR DESCRIPTION
To recieve the real ip address in the backend (e. g. for filters) we need to forward the client's ip address to the backend via headers