### PR TITLE
Enabled gzip compression and HTTP/2

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -38,7 +38,7 @@ services:
     restart: unless-stopped
 
   wwts_nginx:
-    image: nginx:stable-alpine
+    image: macbre/nginx-brotli:latest
     volumes:
       - /etc/letsencrypt:/etc/letsencrypt
       - /usr/share/nginx/html:/usr/share/nginx/html

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -42,8 +42,8 @@ http {
     ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
     ssl_ciphers         HIGH:!aNULL:!MD5;
     
-    gzip on;                                                  # enable gzip compression
-    gzip_types
+    brotli on;                                                # enable brotli compression
+    brotli_types
                   text/plain
                   text/css
                   text/js
@@ -54,8 +54,8 @@ http {
                   application/xml
                   application/rss+xml
                   image/svg+xml;                              # enable compression for all types
-    gzip_proxied    no-cache no-store private expired auth;   # don't send compressed data to caching proxies
-    gzip_min_length 1000;                                     # minimal length for gzip to compress
+    brotli_comp_level 6;                                      # level of compression (max. 11, lowest performance)
+    brotli_min_length 1000;                                   # minimal length for brotli to compress
 
     location ^~ /.well-known/ {
         # allow LE to validate the domain

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -35,12 +35,27 @@ http {
 
     resolver 127.0.0.11 valid=30s;
 
-    listen              443 ssl;
+    listen              443 ssl http2;
     server_name         wewanttosleep.de;
     ssl_certificate     /etc/letsencrypt/live/wewanttosleep.de/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/wewanttosleep.de/privkey.pem;
     ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
     ssl_ciphers         HIGH:!aNULL:!MD5;
+    
+    gzip on;                                                  # enable gzip compression
+    gzip_types
+                  text/plain
+                  text/css
+                  text/js
+                  text/xml
+                  text/javascript
+                  application/javascript
+                  application/json
+                  application/xml
+                  application/rss+xml
+                  image/svg+xml;                              # enable compression for all types
+    gzip_proxied    no-cache no-store private expired auth;   # don't send compressed data to caching proxies
+    gzip_min_length 1000;                                     # minimal length for gzip to compress
 
     location ^~ /.well-known/ {
         # allow LE to validate the domain


### PR DESCRIPTION
Chromes Lighthouse reported poor performance on the ui. 
Compressing data and enabling HTTP/2 were the first tips made by Lighthouse. 
Let's see if this increases performance.
![image](https://user-images.githubusercontent.com/60843765/159891063-38ddee67-becd-460d-b49d-d3b5fc823a2e.png)
